### PR TITLE
Closure<Object> -> Closure<?>

### DIFF
--- a/src/main/java/groovyx/net/http/ChainedHttpConfig.java
+++ b/src/main/java/groovyx/net/http/ChainedHttpConfig.java
@@ -83,7 +83,7 @@ public interface ChainedHttpConfig extends HttpConfig {
     interface ChainedResponse extends Response {
         ChainedResponse getParent();
 
-        default Closure<Object> actualAction(final Integer code) {
+        default Closure<?> actualAction(final Integer code) {
             return traverse(this, (cr) -> cr.getParent(), (cr) -> cr.when(code), Traverser::notNull);
         }
         
@@ -148,7 +148,7 @@ public interface ChainedHttpConfig extends HttpConfig {
         return contentType;
     }
 
-    static Object[] closureArgs(final Closure<Object> closure, final FromServer fromServer, final Object o) {
+    static Object[] closureArgs(final Closure<?> closure, final FromServer fromServer, final Object o) {
         final int size = closure.getMaximumNumberOfParameters();
         final Object[] args = new Object[size];
         if(size >= 1) {

--- a/src/main/java/groovyx/net/http/HttpConfig.java
+++ b/src/main/java/groovyx/net/http/HttpConfig.java
@@ -516,7 +516,7 @@ public interface HttpConfig {
          * @param status the response {@link Status} enum
          * @param closure the closure to be executed
          */
-        void when(Status status, Closure<Object> closure);
+        void when(Status status, Closure<?> closure);
 
         /**
          * Configures the execution of the provided closure "when" the given status code occurs in the response. The `closure` will be called with an instance
@@ -540,7 +540,7 @@ public interface HttpConfig {
          * @param code the response code to be caught
          * @param closure the closure to be executed
          */
-        void when(Integer code, Closure<Object> closure);
+        void when(Integer code, Closure<?> closure);
 
         /**
          * Configures the execution of the provided closure "when" the given status code (as a String) occurs in the response. The `closure` will be
@@ -564,7 +564,7 @@ public interface HttpConfig {
          * @param code the response code to be caught
          * @param closure the closure to be executed
          */
-        void when(String code, Closure<Object> closure);
+        void when(String code, Closure<?> closure);
 
         /**
          * Used to retrieve the "when" closure associated with the given status code.
@@ -572,7 +572,7 @@ public interface HttpConfig {
          * @param code the status code
          * @return the mapped closure
          */
-        Closure<Object> when(Integer code);
+        Closure<?> when(Integer code);
 
         /**
          * Configures the execution of the provided closure "when" a successful response is received (code < 400). The `closure` will be called with
@@ -597,7 +597,7 @@ public interface HttpConfig {
          *
          * @param closure the closure to be executed
          */
-        void success(Closure<Object> closure);
+        void success(Closure<?> closure);
 
         /**
          * Configures the execution of the provided closure "when" a failure response is received (code >= 400). The `closure` will be called with
@@ -622,7 +622,7 @@ public interface HttpConfig {
          *
          * @param closure the closure to be executed
          */
-        void failure(Closure<Object> closure);
+        void failure(Closure<?> closure);
 
         /**
          * Used to specify a response parser ({@link FromServer} instance) for the specified content type, wrapped in a {@link BiFunction}.

--- a/src/main/java/groovyx/net/http/HttpConfigs.java
+++ b/src/main/java/groovyx/net/http/HttpConfigs.java
@@ -305,9 +305,9 @@ public class HttpConfigs {
 
     public static abstract class BaseResponse implements ChainedResponse {
 
-        abstract protected Map<Integer,Closure<Object>> getByCode();
-        abstract protected Closure<Object> getSuccess();
-        abstract protected Closure<Object> getFailure();
+        abstract protected Map<Integer,Closure<?>> getByCode();
+        abstract protected Closure<?> getSuccess();
+        abstract protected Closure<?> getFailure();
         abstract protected Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> getParserMap();
         
         private final ChainedResponse parent;
@@ -320,15 +320,15 @@ public class HttpConfigs {
             this.parent = parent;
         }
         
-        public void when(String code, Closure<Object> closure) {
+        public void when(String code, Closure<?> closure) {
             when(Integer.valueOf(code), closure);
         }
         
-        public void when(Integer code, Closure<Object> closure) {
+        public void when(Integer code, Closure<?> closure) {
             getByCode().put(code, closure);
         }
         
-        public void when(final HttpConfig.Status status, Closure<Object> closure) {
+        public void when(final HttpConfig.Status status, Closure<?> closure) {
             if(status == HttpConfig.Status.SUCCESS) {
                 success(closure);
             }
@@ -337,7 +337,7 @@ public class HttpConfigs {
             }
         }
 
-        public Closure<Object> when(final Integer code) {
+        public Closure<?> when(final Integer code) {
             if(getByCode().containsKey(code)) {
                 return getByCode().get(code);
             }
@@ -370,9 +370,9 @@ public class HttpConfigs {
     }
 
     public static class BasicResponse extends BaseResponse {
-        private final Map<Integer,Closure<Object>> byCode = new LinkedHashMap<>();
-        private Closure<Object> successHandler;
-        private Closure<Object> failureHandler;
+        private final Map<Integer,Closure<?>> byCode = new LinkedHashMap<>();
+        private Closure<?> successHandler;
+        private Closure<?> failureHandler;
         private final Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> parserMap = new LinkedHashMap<>();
 
         protected BasicResponse(final ChainedResponse parent) {
@@ -383,32 +383,32 @@ public class HttpConfigs {
             return parserMap;
         }
         
-        protected Map<Integer,Closure<Object>> getByCode() {
+        protected Map<Integer,Closure<?>> getByCode() {
             return byCode;
         }
 
-        protected Closure<Object> getSuccess() {
+        protected Closure<?> getSuccess() {
             return successHandler;
         }
         
-        protected Closure<Object> getFailure() {
+        protected Closure<?> getFailure() {
             return failureHandler;
         }
 
-        public void success(final Closure<Object> val) {
+        public void success(final Closure<?> val) {
             successHandler = val;
         }
 
-        public void failure(final Closure<Object> val) {
+        public void failure(final Closure<?> val) {
             failureHandler = val;
         }
     }
 
     public static class ThreadSafeResponse extends BaseResponse {
         private final ConcurrentMap<String,BiFunction<ChainedHttpConfig,FromServer,Object>> parserMap = new ConcurrentHashMap<>();
-        private final ConcurrentMap<Integer,Closure<Object>> byCode = new ConcurrentHashMap<>();
-        private volatile Closure<Object> successHandler;
-        private volatile Closure<Object> failureHandler;
+        private final ConcurrentMap<Integer,Closure<?>> byCode = new ConcurrentHashMap<>();
+        private volatile Closure<?> successHandler;
+        private volatile Closure<?> failureHandler;
 
         public ThreadSafeResponse(final ChainedResponse parent) {
             super(parent);
@@ -418,23 +418,23 @@ public class HttpConfigs {
             return parserMap;
         }
         
-        protected Map<Integer,Closure<Object>> getByCode() {
+        protected Map<Integer,Closure<?>> getByCode() {
             return byCode;
         }
 
-        protected Closure<Object> getSuccess() {
+        protected Closure<?> getSuccess() {
             return successHandler;
         }
         
-        protected Closure<Object> getFailure() {
+        protected Closure<?> getFailure() {
             return failureHandler;
         }
 
-        public void success(final Closure<Object> val) {
+        public void success(final Closure<?> val) {
             successHandler = val;
         }
 
-        public void failure(final Closure<Object> val) {
+        public void failure(final Closure<?> val) {
             failureHandler = val;
         }
     }

--- a/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -133,7 +133,7 @@ public class JavaHttpBuilder extends HttpBuilder {
             final JavaFromServer fromServer = new JavaFromServer(requestConfig.getChainedRequest().getUri().toURI());
             try {
                 final BiFunction<ChainedHttpConfig,FromServer,Object> parser = requestConfig.findParser(fromServer.getContentType());
-                final Closure<Object> action = requestConfig.getChainedResponse().actualAction(fromServer.getStatusCode());
+                final Closure<?> action = requestConfig.getChainedResponse().actualAction(fromServer.getStatusCode());
                 if(fromServer.getHasBody()) {
                     final Object o = parser.apply(requestConfig, fromServer);
                     return action.call(ChainedHttpConfig.closureArgs(action, fromServer, o));

--- a/src/main/java/groovyx/net/http/optional/ApacheHttpBuilder.java
+++ b/src/main/java/groovyx/net/http/optional/ApacheHttpBuilder.java
@@ -181,7 +181,7 @@ public class ApacheHttpBuilder extends HttpBuilder {
             final ApacheFromServer fromServer = new ApacheFromServer(requestConfig.getChainedRequest().getUri().toURI(), response);
             try {
                 final BiFunction<ChainedHttpConfig,FromServer,Object> parser = requestConfig.findParser(fromServer.getContentType());
-                final Closure<Object> action = requestConfig.getChainedResponse().actualAction(fromServer.getStatusCode());
+                final Closure<?> action = requestConfig.getChainedResponse().actualAction(fromServer.getStatusCode());
                 if(fromServer.getHasBody()) {
                     final Object o = parser.apply(requestConfig, fromServer);
                     return action.call(ChainedHttpConfig.closureArgs(action, fromServer, o));

--- a/src/test/groovy/groovyx/net/http/StaticCompilationSpec.groovy
+++ b/src/test/groovy/groovyx/net/http/StaticCompilationSpec.groovy
@@ -1,0 +1,27 @@
+package groovyx.net.http;
+
+import spock.lang.*;
+import groovy.transform.CompileStatic;
+
+class StaticCompilationSpec extends Specification {
+
+    @CompileStatic
+    def 'typed handlers should compile static'() {
+        setup:
+        def httpBin = HttpBuilder.configure {
+            request.uri = 'http://httpbin.org/';
+        }
+
+        def resp = httpBin.get {
+            response.success { FromServer fs, Object o ->
+                return o.toString();
+            }
+        }
+
+        String strResp = httpBin.get(String) {
+            response.success { FromServer fs, Object o ->
+                return o.toString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Having Closure<Object> for the handlers causes groovy type checking to
fail when @CompileStatic/@TypeChecked is specified. The changes should
be semantically equivalent at runtime, but they keep compile time type
checking happy.