### PR TITLE
Build Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ artifact on the Bintray web site. Once that is done, you can run:
 
     ./gradlew verifyRelease 
     
-to ensure that the artifacts and site have been published - this step is optional but recommended.
+to ensure that the artifacts and site have been published - this followup step is optional but recommended.
 
-NOTE: Since the artifacts must be confirmed and the site may need some installation time, the `verifyRelease` task cannot be combined with the `release` task.
+> NOTE: Since the artifacts must be confirmed and the site may need some installation time, the `verifyRelease` task cannot be combined with the `release` task.
 
-At this point, the release is complete and you should bump the version in the `develoment` branch, and follow the instructions below to prepare the branch for the next release.
+At this point, the release is complete and you should bump the version in the `development` branch, and follow the instructions below to prepare the branch for the next release.
 
 ## Version Updates
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ which will provide the site at http://localhost:8080. Once you are ready to publ
     
 This task will push the site contents into the `gh-pages` branch of the project, assuming you have permissions to push content into the repo.
 
+## Artifact Release
+    
+When ready to release a new version of the project, create a Pull Request from the `development` branch to the `master` branch and accept it or have it reviewed. Once the Pull Request
+has been merged into `master`, run:
+
+    ./gradlew release
+    
+which will check the documented project version against the project version, publish the artifact and the documentation web site. You will need to confirm the publication of the new
+artifact on the Bintray web site. Once that is done, you can run:
+
+    ./gradlew verifyRelease 
+    
+to ensure that the artifacts and site have been published - this step is optional but recommended.
+
+NOTE: Since the artifacts must be confirmed and the site may need some installation time, the `verifyRelease` task cannot be combined with the `release` task.
+
+At this point, the release is complete and you should bump the version in the `develoment` branch, and follow the instructions below to prepare the branch for the next release.
+
 ## Version Updates
 
 When updating the version of the project, the documented version should also be updated using the `updateVersion` task. Modify the version in the project `build.gradle` file and make note of the existing version then run:

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+
+* Add site link (https://dwclark.github.io/http-builder-ng/) to main GitHub page
+    - On the main GitHub page under the menu bar to the right of "The Easy Http Client for Groovy" you should see an "Edit" button
+    - click the edit button and paste the URL in the web site box and click "Save"
+
+* Setup CI - instructions to dave
+
+
+    

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,0 @@
-
-* Add site link (https://dwclark.github.io/http-builder-ng/) to main GitHub page
-    - On the main GitHub page under the menu bar to the right of "The Easy Http Client for Groovy" you should see an "Edit" button
-    - click the edit button and paste the URL in the web site box and click "Save"
-
-* Setup CI - instructions to dave
-
-
-    

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,8 @@ asciidoctor {
         encoding: 'utf-8'
 }
 
+tasks.bintrayUpload.dependsOn build
+
 task site(group: 'Documentation', description: 'Builds the documentation web site.', dependsOn: ['build', 'javadoc', 'jacocoTestReport', 'findbugsMain', 'asciidoctor', 'jbake']) << {
     logger.lifecycle 'Building documentation web site...'
 
@@ -161,18 +163,18 @@ task site(group: 'Documentation', description: 'Builds the documentation web sit
     }
 
     // Make the jacoco .resources directory non-hidden so the gh pages plugin will find it
-    ant.move(todir:'build/jbake/jacoco/test/html/resources'){
+    ant.move(todir: 'build/jbake/jacoco/test/html/resources') {
         fileset(dir: 'build/jbake/jacoco/test/html/.resources')
     }
 
-    ant.replace(dir:'build/jbake/jacoco/test/html', token:'.resources/', value:'resources/')
+    ant.replace(dir: 'build/jbake/jacoco/test/html', token: '.resources/', value: 'resources/')
 
     ant.copy(todir: 'build/jbake/guide') {
         fileset(dir: 'build/asciidoc', includes: '**/**')
     }
 }
 
-task publishSite(type: GradleBuild, group: 'Publishing', description: 'Publishes the documentation web site.', dependsOn:['site']) {
+task publishSite(type: GradleBuild, group: 'Publishing', description: 'Publishes the documentation web site.', dependsOn: ['site']) {
     buildFile = 'publish.gradle'
     tasks = ['publishGhPages']
 }
@@ -188,13 +190,77 @@ tasks.withType(FindBugs) {
     }
 }
 
-task updateVersion(group:'Documentation', description:'Updates the version in documentation based on the project version') << {
+task updateVersion(group: 'Documentation', description: 'Updates the version in documentation based on the project version') << {
     String newVersion = project.version
     String oldVersion = project.property('from')
 
     logger.lifecycle "Updating documentation versions from ${oldVersion} to ${newVersion}..."
 
-    ant.replace(file:'README.md', token:oldVersion, value:newVersion)
-    ant.replace(dir:'src/docs/asciidoc', token:oldVersion, value:newVersion)
-    ant.replace(dir:'src/jbake/templates', token:oldVersion, value:newVersion)
+    ant.replace(file: 'README.md', token: oldVersion, value: newVersion)
+    ant.replace(dir: 'src/docs/asciidoc', token: oldVersion, value: newVersion)
+    ant.replace(dir: 'src/jbake/templates', token: oldVersion, value: newVersion)
+}
+
+task checkVersion(group: 'Verification', description: 'Verify that the project version is reflected in the documentation.') << {
+    logger.lifecycle "Verifying that the documentation references version ${project.version}..."
+
+    // Not the most efficient way to do this but should be ok for now
+    boolean documented = ['README.md', 'src/docs/asciidoc/index.adoc', 'src/jbake/templates/index.gsp'].every { f ->
+        boolean ok = project.file(f).text.contains(project.version)
+
+        logger.info " - Checking: $f: $ok"
+        ok
+    }
+
+    assert documented, 'The documented project version does not match the project version: Run "./gradlew updateVersion -Pfrom=OLD_VERSION" and try again.'
+}
+
+task verifyArtifacts(group: 'Verification', description: 'Verifies that the published artifacts exist in the remote repository.') << {
+    def repo = "https://dl.bintray.com/davidwclark/dclark/org/codehaus/groovy/modules/http-builder-ng/${project.version}/"
+    def artifacts = ['-sources.jar', '.jar', '.pom'].collect { "http-builder-ng-${project.version}${it}" }
+
+    logger.lifecycle "Verifying that artifacts exist at ${repo}..."
+
+    boolean published = artifacts.every { art ->
+        boolean ok = checkUrl("${repo}${art}")
+        logger.info " - Checking: ${repo}${art}: $ok"
+        ok
+    }
+
+    assert published, 'Some or all of the artifacts are not published. Run with --info for more details.'
+}
+
+task verifySite(group: 'Verification', description: 'Verifies that the documentation site exists at the expected address.') << {
+    def siteUrl = 'http://localhost:8080'
+
+    logger.lifecycle "Verifying that site exists at ${siteUrl}..."
+
+    // we'll just hit the important ones
+    boolean exists = [
+        '/index.html', '/guide/html5/index.html', '/javadoc/index.html'
+    ].every { page ->
+        boolean ok = checkUrl("${siteUrl}${page}")
+        logger.info " - Checking: ${siteUrl}${page}: $ok"
+        ok
+    }
+
+    assert exists, 'Some or all of the documentation site pages are not published. Run with --info for more details.'
+}
+
+task release(group: 'Development', description: 'Release a new version of the library.', dependsOn: ['checkVersion', 'bintrayUpload', 'publishSite']) << {
+    logger.lifecycle 'Library has been released - confirm the Bintray publications and run "./gradlew verifyRelease"'
+}
+
+task verifyRelease(group: 'Verification', description: 'Verifies that the release was successful.', dependsOn: ['verifyArtifacts', 'verifySite']) << {
+    logger.lifecycle 'Release has been verified.'
+}
+
+static boolean checkUrl(String url) {
+    try {
+        def conn = url.toURL().openConnection() as HttpURLConnection
+        conn.requestMethod = 'HEAD'
+        return conn.responseCode == 200
+    } catch (ex) {
+        return false
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ task site(group: 'Documentation', description: 'Builds the documentation web sit
     }
 }
 
-task publishSite(type: GradleBuild, group: 'Publishing', description: 'Publishes the documentation web site.') {
+task publishSite(type: GradleBuild, group: 'Publishing', description: 'Publishes the documentation web site.', dependsOn:['site']) {
     buildFile = 'publish.gradle'
     tasks = ['publishGhPages']
 }

--- a/src/test/groovy/groovyx/net/http/StaticCompilationSpec.groovy
+++ b/src/test/groovy/groovyx/net/http/StaticCompilationSpec.groovy
@@ -1,8 +1,25 @@
-package groovyx.net.http;
+/*
+ * Copyright (C) 2016 David Clark
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package groovyx.net.http
 
-import spock.lang.*;
-import groovy.transform.CompileStatic;
+import groovy.transform.CompileStatic
+import spock.lang.Requires
+import spock.lang.Specification;
 
+@Requires(HttpBin)
 class StaticCompilationSpec extends Specification {
 
     @CompileStatic


### PR DESCRIPTION
I have added a handful of Gradle tasks to simplify artifact release. There is a section of the README with the work flow, but basically:

1. merge from `development` to `master`
1. Run: `./gradlew release` (with your bintray credentials)
1. Confirm the artifact on Bintray and let the site update
1. Run: `./gradlew verifyRelease`

Also, the the `release` task will complain and fail if you have not updated the documented version (i.e. the project version is not what's in the documentation).

This should make things a bit smoother. I am considering pulling some or all of this out into a Gradle plugin, but for now, we have a large build file. :-)