### PR TITLE
Jackson simplification, enable warnings in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,10 @@ tasks.withType(FindBugs) {
     }
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+}
+
 task updateVersion(group: 'Documentation', description: 'Updates the version in documentation based on the project version') << {
     String newVersion = project.version
     String oldVersion = project.property('from')

--- a/src/main/java/groovyx/net/http/ChainedHttpConfig.java
+++ b/src/main/java/groovyx/net/http/ChainedHttpConfig.java
@@ -82,7 +82,8 @@ public interface ChainedHttpConfig extends HttpConfig {
 
     interface ChainedResponse extends Response {
         ChainedResponse getParent();
-
+        Class<?> getType();
+        
         default BiFunction<FromServer, Object, ?> actualAction(final Integer code) {
             return traverse(this, (cr) -> cr.getParent(), (cr) -> cr.when(code), Traverser::notNull);
         }
@@ -105,8 +106,8 @@ public interface ChainedHttpConfig extends HttpConfig {
     Map<Map.Entry<String,Object>,Object> getContextMap();
     
     default Object actualContext(final String contentType, final Object id) {
-        final Map.Entry<String,Object> key = new AbstractMap.SimpleImmutableEntry(contentType, id);
-        final Map.Entry<String,Object> anyKey = new AbstractMap.SimpleImmutableEntry(ContentTypes.ANY.getAt(0), id);
+        final Map.Entry<String,Object> key = new AbstractMap.SimpleImmutableEntry<>(contentType, id);
+        final Map.Entry<String,Object> anyKey = new AbstractMap.SimpleImmutableEntry<>(ContentTypes.ANY.getAt(0), id);
         
         final Function<ChainedHttpConfig,Object> theValue = (config) -> {
             Object ctx = config.getContextMap().get(key);

--- a/src/main/java/groovyx/net/http/HttpBuilder.java
+++ b/src/main/java/groovyx/net/http/HttpBuilder.java
@@ -281,7 +281,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T get(final Class<T> type, @DelegatesTo(HttpConfig.class) final Closure closure) {
-        return type.cast(get(closure));
+        return type.cast(interceptors.get(HttpVerb.GET).apply(configureRequest(type, closure), this::doGet));
     }
 
     /**
@@ -307,7 +307,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T get(final Class<T> type, final Consumer<HttpConfig> configuration){
-        return type.cast(get(configuration));
+        return type.cast(interceptors.get(HttpVerb.GET).apply(configureRequest(type, configuration), this::doGet));
     }
 
     /**
@@ -470,7 +470,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T head(final Class<T> type, @DelegatesTo(HttpConfig.class) final Closure closure) {
-        return type.cast(head(closure));
+        return type.cast(interceptors.get(HttpVerb.HEAD).apply(configureRequest(type, closure), this::doHead));
     }
 
     /**
@@ -496,7 +496,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T head(final Class<T> type, final Consumer<HttpConfig> configuration){
-        return type.cast(head(configuration));
+        return type.cast(interceptors.get(HttpVerb.HEAD).apply(configureRequest(type, configuration), this::doHead));
     }
 
     /**
@@ -667,7 +667,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the result of the request cast to the specified type
      */
     public <T> T post(final Class<T> type, @DelegatesTo(HttpConfig.class) final Closure closure) {
-        return type.cast(post(closure));
+        return type.cast(interceptors.get(HttpVerb.POST).apply(configureRequest(type, closure), this::doPost));
     }
 
     /**
@@ -693,7 +693,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T post(final Class<T> type, final Consumer<HttpConfig> configuration) {
-        return type.cast(post(configuration));
+        return type.cast(interceptors.get(HttpVerb.POST).apply(configureRequest(type, configuration), this::doPost));
     }
 
     /**
@@ -865,7 +865,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the result of the request cast to the specified type
      */
     public <T> T put(final Class<T> type, @DelegatesTo(HttpConfig.class) final Closure closure) {
-        return type.cast(put(closure));
+        return type.cast(interceptors.get(HttpVerb.PUT).apply(configureRequest(type, closure), this::doPut));
     }
 
     /**
@@ -891,7 +891,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T put(final Class<T> type, final Consumer<HttpConfig> configuration) {
-        return type.cast(put(configuration));
+        return type.cast(interceptors.get(HttpVerb.PUT).apply(configureRequest(type, configuration), this::doPut));
     }
 
     /**
@@ -1061,7 +1061,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the result of the request cast to the specified type
      */
     public <T> T delete(final Class<T> type, @DelegatesTo(HttpConfig.class) final Closure closure) {
-        return type.cast(delete(closure));
+        return type.cast(interceptors.get(HttpVerb.DELETE).apply(configureRequest(type, closure), this::doDelete));
     }
 
     /**
@@ -1087,7 +1087,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content cast to the specified type
      */
     public <T> T delete(final Class<T> type, final Consumer<HttpConfig> configuration) {
-        return type.cast(delete(configuration));
+        return type.cast(interceptors.get(HttpVerb.DELETE).apply(configureRequest(type, configuration), this::doDelete));
     }
 
     /**
@@ -1232,7 +1232,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object get(@DelegatesTo(HttpConfig.class) final Closure closure) {
-        return interceptors.get(HttpVerb.GET).apply(configureRequest(closure), this::doGet);
+        return get(Object.class, closure);
     }
 
     /**
@@ -1256,7 +1256,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object get(final Consumer<HttpConfig> configuration){
-        return interceptors.get(HttpVerb.GET).apply(configureRequest(configuration), this::doGet);
+        return get(Object.class, configuration);
     }
 
     /**
@@ -1278,7 +1278,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content - which will be `null` unless provided by a `request.when()` closure
      */
     public Object head(@DelegatesTo(HttpConfig.class) final Closure closure) {
-        return interceptors.get(HttpVerb.HEAD).apply(configureRequest(closure), this::doHead);
+        return head(Object.class, closure);
     }
 
     /**
@@ -1302,7 +1302,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object head(final Consumer<HttpConfig> configuration){
-        return interceptors.get(HttpVerb.HEAD).apply(configureRequest(configuration), this::doHead);
+        return head(Object.class, configuration);
     }
 
     /**
@@ -1326,7 +1326,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object post(@DelegatesTo(HttpConfig.class) final Closure closure) {
-        return interceptors.get(HttpVerb.POST).apply(configureRequest(closure), this::doPost);
+        return post(Object.class, closure);
     }
 
     /**
@@ -1350,7 +1350,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object post(final Consumer<HttpConfig> configuration) {
-        return interceptors.get(HttpVerb.POST).apply(configureRequest(configuration), this::doPost);
+        return post(Object.class, configuration);
     }
 
     /**
@@ -1374,7 +1374,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object put(@DelegatesTo(HttpConfig.class) final Closure closure) {
-        return interceptors.get(HttpVerb.PUT).apply(configureRequest(closure), this::doPut);
+        return put(Object.class, closure);
     }
 
     /**
@@ -1398,7 +1398,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object put(final Consumer<HttpConfig> configuration) {
-        return interceptors.get(HttpVerb.PUT).apply(configureRequest(configuration), this::doPut);
+        return put(Object.class, configuration);
     }
 
     /**
@@ -1420,7 +1420,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object delete(@DelegatesTo(HttpConfig.class) final Closure closure) {
-        return interceptors.get(HttpVerb.DELETE).apply(configureRequest(closure), this::doDelete);
+        return delete(Object.class, closure);
     }
 
     /**
@@ -1444,7 +1444,7 @@ public abstract class HttpBuilder implements Closeable {
      * @return the resulting content
      */
     public Object delete(final Consumer<HttpConfig> configuration) {
-        return interceptors.get(HttpVerb.DELETE).apply(configureRequest(configuration), this::doDelete);
+        return delete(Object.class, configuration);
     }
 
     protected abstract Object doGet(final ChainedHttpConfig config);
@@ -1461,17 +1461,19 @@ public abstract class HttpBuilder implements Closeable {
 
     public abstract Executor getExecutor();
 
-    private ChainedHttpConfig configureRequest(final Closure closure) {
-        final ChainedHttpConfig myConfig = HttpConfigs.requestLevel(getObjectConfig());
+    private ChainedHttpConfig configureRequest(final Class<?> type, final Closure closure) {
+        final HttpConfigs.BasicHttpConfig myConfig = HttpConfigs.requestLevel(getObjectConfig());
         closure.setDelegate(myConfig);
         closure.setResolveStrategy(Closure.DELEGATE_FIRST);
         closure.call();
+        myConfig.getChainedResponse().setType(type);
         return myConfig;
     }
 
-    private ChainedHttpConfig configureRequest(final Consumer<HttpConfig> configuration) {
-        final ChainedHttpConfig myConfig = HttpConfigs.requestLevel(getObjectConfig());
+    private ChainedHttpConfig configureRequest(final Class<?> type, final Consumer<HttpConfig> configuration) {
+        final HttpConfigs.BasicHttpConfig myConfig = HttpConfigs.requestLevel(getObjectConfig());
         configuration.accept(myConfig);
+        myConfig.getChainedResponse().setType(type);
         return myConfig;
     }
 }

--- a/src/main/java/groovyx/net/http/HttpConfigs.java
+++ b/src/main/java/groovyx/net/http/HttpConfigs.java
@@ -196,7 +196,7 @@ public class HttpConfigs {
         private Object body;
         private final Map<String,BiConsumer<ChainedHttpConfig,ToServer>> encoderMap = new LinkedHashMap<>();
         private BasicAuth auth = new BasicAuth();
-        private List<Cookie> cookies = new ArrayList(1);
+        private List<Cookie> cookies = new ArrayList<>(1);
         
         protected BasicRequest(ChainedRequest parent) {
             super(parent);
@@ -257,7 +257,7 @@ public class HttpConfigs {
         private volatile Object body;
         private final ConcurrentMap<String,BiConsumer<ChainedHttpConfig,ToServer>> encoderMap = new ConcurrentHashMap<>();
         private final ThreadSafeAuth auth;
-        private final List<Cookie> cookies = new CopyOnWriteArrayList();
+        private final List<Cookie> cookies = new CopyOnWriteArrayList<>();
 
         public ThreadSafeRequest(final ChainedRequest parent) {
             super(parent);
@@ -373,6 +373,8 @@ public class HttpConfigs {
                 parser(contentType, val);
             }
         }
+
+        public abstract void setType(Class<?> type);
     }
 
     public static class BasicResponse extends BaseResponse {
@@ -381,7 +383,8 @@ public class HttpConfigs {
         private BiFunction<FromServer, Object, ?> successHandler;
         private BiFunction<FromServer, Object, ?> failureHandler;
         private final Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> parserMap = new LinkedHashMap<>();
-
+        private Class<?> type = Object.class;
+        
         protected BasicResponse(final ChainedResponse parent) {
             super(parent);
         }
@@ -409,6 +412,14 @@ public class HttpConfigs {
         public void failure(final BiFunction<FromServer, Object, ?> val) {
             failureHandler = val;
         }
+
+        public Class<?> getType() {
+            return type;
+        }
+
+        public void setType(Class<?> val) {
+            type = val;
+        }
     }
 
     public static class ThreadSafeResponse extends BaseResponse {
@@ -417,6 +428,7 @@ public class HttpConfigs {
         private final ConcurrentMap<Integer,BiFunction<FromServer, Object, ?>> byCode = new ConcurrentHashMap<>();
         private volatile BiFunction<FromServer, Object, ?> successHandler;
         private volatile BiFunction<FromServer, Object, ?> failureHandler;
+        private volatile Class<?> type = Object.class;
 
         public ThreadSafeResponse(final ChainedResponse parent) {
             super(parent);
@@ -444,6 +456,14 @@ public class HttpConfigs {
 
         public void failure(final BiFunction<FromServer, Object, ?> val) {
             failureHandler = val;
+        }
+
+        public Class<?> getType() {
+            return type;
+        }
+
+        public void setType(final Class<?> val) {
+            type = val;
         }
     }
 
@@ -541,19 +561,19 @@ public class HttpConfigs {
             }
         }
 
-        public Request getRequest() {
+        public BasicRequest getRequest() {
             return request;
         }
 
-        public Response getResponse() {
+        public BasicResponse getResponse() {
             return response;
         }
 
-        public ChainedRequest getChainedRequest() {
+        public BasicRequest getChainedRequest() {
             return request;
         }
 
-        public ChainedResponse getChainedResponse() {
+        public BasicResponse getChainedResponse() {
             return response;
         }
 
@@ -601,7 +621,7 @@ public class HttpConfigs {
         return new BasicHttpConfig(parent);
     }
 
-    public static ChainedHttpConfig requestLevel(final ChainedHttpConfig parent) {
+    public static BasicHttpConfig requestLevel(final ChainedHttpConfig parent) {
         return new BasicHttpConfig(parent);
     }
 

--- a/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -76,7 +76,7 @@ public class JavaHttpBuilder extends HttpBuilder {
             connection.addRequestProperty("Accept-Encoding", "gzip, deflate");
 
             final URI uri = cr.getUri().toURI();
-            final List<Cookie> cookies = cr.actualCookies(new ArrayList());
+            final List<Cookie> cookies = cr.actualCookies(new ArrayList<>());
             for(Cookie cookie : cookies) {
                 final HttpCookie httpCookie = new HttpCookie(cookie.getName(), cookie.getValue());
                 httpCookie.setVersion(clienConfig.getCookieVersion());

--- a/src/main/java/groovyx/net/http/NativeHandlers.java
+++ b/src/main/java/groovyx/net/http/NativeHandlers.java
@@ -109,9 +109,9 @@ public class NativeHandlers {
             return body;
         }
 
-        public static void checkTypes(final Object body, final Class[] allowedTypes) {
-            final Class type = body.getClass();
-            for(Class allowed : allowedTypes) {
+        public static void checkTypes(final Object body, final Class<?>[] allowedTypes) {
+            final Class<?> type = body.getClass();
+            for(Class<?> allowed : allowedTypes) {
                 if(allowed.isAssignableFrom(type)) {
                     return;
                 }

--- a/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/src/main/java/groovyx/net/http/UriBuilder.java
@@ -424,7 +424,7 @@ public abstract class UriBuilder {
             return path;
         }
 
-        private Map<String, Object> query = new ConcurrentHashMap();
+        private Map<String, Object> query = new ConcurrentHashMap<>();
 
         public UriBuilder setQuery(Map<String, ?> val) {
             query.putAll(val);

--- a/src/main/java/groovyx/net/http/optional/ApacheHttpBuilder.java
+++ b/src/main/java/groovyx/net/http/optional/ApacheHttpBuilder.java
@@ -160,6 +160,7 @@ public class ApacheHttpBuilder extends HttpBuilder {
             return true;
         }
 
+        @SuppressWarnings("deprecation") //apache httpentity requires method
         public void consumeContent() throws IOException {
             inputStream.close();
         }
@@ -302,7 +303,7 @@ public class ApacheHttpBuilder extends HttpBuilder {
 
         //technically cookies are headers, so add them here
         final URI uri = cr.getUri().toURI();
-        List<Cookie> cookies = cr.actualCookies(new ArrayList());
+        List<Cookie> cookies = cr.actualCookies(new ArrayList<>());
         for(Cookie cookie : cookies) {
             final BasicClientCookie apacheCookie = new BasicClientCookie(cookie.getName(), cookie.getValue());
             apacheCookie.setVersion(clientConfig.getCookieVersion());

--- a/src/main/java/groovyx/net/http/optional/Csv.java
+++ b/src/main/java/groovyx/net/http/optional/Csv.java
@@ -108,7 +108,7 @@ public class Csv {
         final StringWriter writer = new StringWriter();
         final CSVWriter csvWriter = ctx.makeWriter(new StringWriter());
 
-        Iterable<Object> iterable = (Iterable) body;
+        Iterable<?> iterable = (Iterable<?>) body;
         for(Object o : iterable) {
             csvWriter.writeNext((String[]) o);
         }

--- a/src/main/java/groovyx/net/http/optional/Jackson.java
+++ b/src/main/java/groovyx/net/http/optional/Jackson.java
@@ -31,13 +31,11 @@ import static groovyx.net.http.NativeHandlers.Encoders.handleRawUpload;
 public class Jackson {
 
     public static final String OBJECT_MAPPER_ID = "0w4XJJnlTNK8dvISuCDTlsusPQE=";
-    public static final String RESPONSE_TYPE = "GWW35uTkrHwonPt5odeUqBdR3EU=";
 
     public static Object parse(final ChainedHttpConfig config, final FromServer fromServer) {
         try {
             final ObjectMapper mapper = (ObjectMapper) config.actualContext(fromServer.getContentType(), OBJECT_MAPPER_ID);
-            final Class type = (Class) config.actualContext(fromServer.getContentType(), RESPONSE_TYPE);
-            return mapper.readValue(fromServer.getReader(), type);
+            return mapper.readValue(fromServer.getReader(), config.getChainedResponse().getType());
         }
         catch(IOException e) {
             throw new RuntimeException(e);
@@ -52,7 +50,6 @@ public class Jackson {
 
             final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
             final ObjectMapper mapper = (ObjectMapper) config.actualContext(request.actualContentType(), OBJECT_MAPPER_ID);
-            final Class type = (Class) config.actualContext(request.actualContentType(), RESPONSE_TYPE);
             final StringWriter writer = new StringWriter();
             mapper.writeValue(writer, request.actualBody());
             ts.toServer(new CharSequenceInputStream(writer.toString(), request.actualCharset()));
@@ -69,10 +66,5 @@ public class Jackson {
     public static void use(final HttpConfig config) {
         config.getRequest().encoder(ContentTypes.JSON, Jackson::encode);
         config.getResponse().parser(ContentTypes.JSON, Jackson::parse);
-    }
-    
-    public static void toType(final HttpConfig config, final Class type) {
-        use(config);
-        config.context(ContentTypes.JSON, RESPONSE_TYPE, type);
     }
 }

--- a/src/test/groovy/groovyx/net/http/HttpBuilderTest.groovy
+++ b/src/test/groovy/groovyx/net/http/HttpBuilderTest.groovy
@@ -306,14 +306,13 @@ class HttpBuilderTest extends Specification {
         def accept = ['application/json', 'application/javascript', 'text/javascript'];
 
         expect:
-        httpBin.post {
+        httpBin.post(Map) {
             request.uri.path = '/post'
             request.uri.query = [one: '1', two: '2'];
             request.accept = accept;
             request.body = toSend;
             request.contentType = 'application/json';
             Jackson.mapper(delegate, objectMapper);
-            Jackson.toType(delegate, Map);
         }.with {
             (it instanceof Map &&
                 headers.Accept.split(';') as List<String> == accept &&

--- a/src/test/groovy/groovyx/net/http/JavaHttpBuilderTest.groovy
+++ b/src/test/groovy/groovyx/net/http/JavaHttpBuilderTest.groovy
@@ -297,14 +297,13 @@ class JavaHttpBuilderTest extends Specification {
         def accept = [ 'application/json','application/javascript','text/javascript' ];
 
         expect:
-        httpBin.post {
+        httpBin.post(Map) {
             request.uri.path = '/post'
             request.uri.query = [ one: '1', two: '2' ];
             request.accept = accept;
             request.body = toSend;
             request.contentType = 'application/json';
             Jackson.mapper(delegate, objectMapper);
-            Jackson.toType(delegate, Map);
         }.with {
             (it instanceof Map &&
              headers.Accept.split(';') as List<String> == accept &&


### PR DESCRIPTION
1) Enhanced ChainedHttpConfig.ChainedResponse to include response type
information. This simplifies Jackson configuration and possibly helps
other libraries do work correctly.

2) Enabled unchecked and deprecation warnings, fixed issues and
suppressed one deprecation warning.