### PR TITLE
Issue #187 : Use the charset of the response from the server.

### DIFF
--- a/http-builder-ng-core/src/main/java/groovyx/net/http/FromServer.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/FromServer.java
@@ -453,14 +453,9 @@ public interface FromServer {
      */
     default Charset getCharset() {
         final Header.CombinedMap header = (Header.CombinedMap) Header.find(getHeaders(), "Content-Type");
-        if (header == null) {
-            return StandardCharsets.UTF_8;
+        if (header != null && header.getParsed().containsKey("charset")) {
+            return Charset.forName(header.getParsed().get("charset"));
         }
-
-        if (header.getParsed().containsKey("charset")) {
-            Charset.forName(header.getParsed().get("charset"));
-        }
-
         return StandardCharsets.UTF_8;
     }
 


### PR DESCRIPTION
Hello,

A fix related to the issue #187 : 
A `return` was missing to get the charset when it was specify in the Content-Type header. Even if the response was different from UTF-8, we always had this charset.